### PR TITLE
Change `PageRangeFormat::format` to follow Pandoc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3661,7 +3661,6 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::reversed_empty_ranges)]
     fn page_range() {
         fn run(format: PageRangeFormat, start: i32, end: i32) -> String {
             let mut buf = String::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1045,7 +1045,7 @@ pub struct Citation {
 impl Citation {
     /// Return the default value for `cite_group_delimiter` if implicitly needed
     /// due to presence of a `collapse` attribute.
-    pub const DEFAULT_CITE_GROUP_DELIMITER: &str = ", ";
+    pub const DEFAULT_CITE_GROUP_DELIMITER: &'static str = ", ";
 
     /// Return a citation with default settings and the given layout.
     pub fn with_layout(layout: Layout) -> Self {
@@ -1722,7 +1722,7 @@ to_affixes!(DatePart);
 
 impl DatePart {
     /// Retrieve the default delimiter for the date part.
-    pub const DEFAULT_DELIMITER: &str = "–";
+    pub const DEFAULT_DELIMITER: &'static str = "–";
 
     /// Retrieve the form.
     pub fn form(&self) -> DateStrongAnyForm {
@@ -3661,6 +3661,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::reversed_empty_ranges)]
     fn page_range() {
         let mut buf = String::new();
         PageRangeFormat::Chicago15.format(100..4, &mut buf, None).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3663,8 +3663,63 @@ mod test {
     #[test]
     #[allow(clippy::reversed_empty_ranges)]
     fn page_range() {
-        let mut buf = String::new();
-        PageRangeFormat::Chicago15.format(100..4, &mut buf, None).unwrap();
-        assert_eq!("100–104", buf);
+        fn run(format: PageRangeFormat, start: i32, end: i32) -> String {
+            let mut buf = String::new();
+            format.format(start..end, &mut buf, None).unwrap();
+            buf
+        }
+
+        let c15 = PageRangeFormat::Chicago15;
+        let c16 = PageRangeFormat::Chicago16;
+        let exp = PageRangeFormat::Expanded;
+        let min = PageRangeFormat::Minimal;
+        let mi2 = PageRangeFormat::MinimalTwo;
+
+        // https://docs.citationstyles.org/en/stable/specification.html#appendix-v-page-range-formats
+
+        assert_eq!("3–10", run(c15, 3, 10));
+        assert_eq!("71–72", run(c15, 71, 72));
+        assert_eq!("100–104", run(c15, 100, 4));
+        assert_eq!("600–613", run(c15, 600, 613));
+        assert_eq!("1100–1123", run(c15, 1100, 1123));
+        assert_eq!("107–8", run(c15, 107, 108));
+        assert_eq!("505–17", run(c15, 505, 517));
+        assert_eq!("1002–6", run(c15, 1002, 1006));
+        assert_eq!("321–25", run(c15, 321, 325));
+        assert_eq!("415–532", run(c15, 415, 532));
+        assert_eq!("11564–68", run(c15, 11564, 11568));
+        assert_eq!("13792–803", run(c15, 13792, 13803));
+        assert_eq!("1496–1504", run(c15, 1496, 1504));
+        assert_eq!("2787–2816", run(c15, 2787, 2816));
+
+        assert_eq!("3–10", run(c16, 3, 10));
+        assert_eq!("71–72", run(c16, 71, 72));
+        assert_eq!("92–113", run(c16, 92, 113));
+        assert_eq!("100–104", run(c16, 100, 4));
+        assert_eq!("600–613", run(c16, 600, 613));
+        assert_eq!("1100–1123", run(c16, 1100, 1123));
+        assert_eq!("107–8", run(c16, 107, 108));
+        assert_eq!("505–17", run(c16, 505, 517));
+        assert_eq!("1002–6", run(c16, 1002, 1006));
+        assert_eq!("321–25", run(c16, 321, 325));
+        assert_eq!("415–532", run(c16, 415, 532));
+        assert_eq!("1087–89", run(c16, 1087, 1089));
+        assert_eq!("1496–500", run(c16, 1496, 1500));
+        assert_eq!("11564–68", run(c16, 11564, 11568));
+        assert_eq!("13792–803", run(c16, 13792, 13803));
+        assert_eq!("12991–3001", run(c16, 12991, 13001));
+
+        assert_eq!("42–45", run(exp, 42, 45));
+        assert_eq!("321–328", run(exp, 321, 328));
+        assert_eq!("2787–2816", run(exp, 2787, 2816));
+
+        assert_eq!("42–5", run(min, 42, 45));
+        assert_eq!("321–8", run(min, 321, 328));
+        assert_eq!("2787–816", run(min, 2787, 2816));
+
+        assert_eq!("7–8", run(mi2, 7, 8));
+        assert_eq!("42–45", run(mi2, 42, 45));
+        assert_eq!("321–28", run(mi2, 321, 328));
+        assert_eq!("2787–816", run(mi2, 2787, 2816));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub mod taxonomy;
 mod util;
 
 use std::fmt::{self, Debug};
+use std::iter::repeat;
 use std::num::{NonZeroI16, NonZeroUsize};
 
 use quick_xml::de::{Deserializer, SliceReader};
@@ -640,90 +641,158 @@ pub enum PageRangeFormat {
 
 impl PageRangeFormat {
     /// Use a page range format to format a range of pages.
+    ///
+    /// Closely follows the [Haskell implementation of pandoc](https://hackage.haskell.org/package/citeproc-0.8.1/docs/src/Citeproc.Eval.html#pageRange).
     pub fn format(
         self,
-        range: std::ops::Range<i32>,
+        ranges: &str,
         buf: &mut impl fmt::Write,
         separator: Option<&str>,
     ) -> Result<(), fmt::Error> {
         let separator = separator.unwrap_or("–");
 
-        write!(buf, "{}{}", range.start, separator)?;
-        let end = if range.end >= range.start {
-            range.end
-        } else {
-            expand(range.start, range.end)
-        };
+        // Split input into different ranges separated by `&` or `,`
+        let ranges =
+            group_by(ranges, |c, d| !(c == ',' || c == '&' || d == ',' || d == '&'))
+                .map(str::trim);
 
-        match self {
-            _ if range.start < 0 || range.end < 0 => write!(buf, "{}", end),
-            PageRangeFormat::Expanded => write!(buf, "{}", end),
-
-            PageRangeFormat::Chicago15 | PageRangeFormat::Chicago16
-                if range.start < 100 || range.start % 100 == 0 =>
-            {
-                write!(buf, "{}", end)
-            }
-            PageRangeFormat::Minimal => {
-                write!(buf, "{}", changed_part(range.start, end, 0))
-            }
-            PageRangeFormat::MinimalTwo if end < 10 => {
-                write!(buf, "{}", changed_part(range.start, end, 1))
-            }
-            PageRangeFormat::Chicago15
-                if range.start > 100 && (1..10).contains(&(range.start % 100)) =>
-            {
-                write!(buf, "{}", changed_part(range.start, end, 0))
-            }
-            PageRangeFormat::Chicago15
-                if closest_smaller_power_of_10(range.start) == 1000 =>
-            {
-                let changed = changed_part(range.start, end, 1);
-                if closest_smaller_power_of_10(changed) == 100 {
-                    write!(buf, "{end}")
+        // Write output for each range.
+        ranges
+            .map(|range| {
+                if range == "&" {
+                    write!(buf, " & ")
+                } else if range == "," {
+                    write!(buf, ", ")
                 } else {
-                    write!(buf, "{changed}")
+                    // If `-` chars are escaped, write `-`.
+                    let mut range_parts = if range.contains("\\-") {
+                        return write!(buf, "{}", range.replace("\\-", "-"));
+                    } else {
+                        // Otherwise, split into the two halves of the dash.
+                        range.split(|c| c == '-' || c == '–').map(str::trim)
+                    };
+
+                    // Get start and end; if less than two elements exist, just output what is there
+                    let (start, end) = if let Some(start) = range_parts.next() {
+                        if let Some(end) = range_parts.next() {
+                            (start, end)
+                        } else {
+                            return write!(buf, "{start}");
+                        }
+                    } else {
+                        return write!(buf, "");
+                    };
+
+                    // Split into the maximal suffix that is all digits (`x`|`y`),
+                    // and the prefix.
+                    let (start_pre, x) = split_max_digit_suffix(start);
+                    let (end_pre, y) = split_max_digit_suffix(end);
+
+                    if start_pre == end_pre {
+                        let pref = start_pre;
+                        let x_len = x.len();
+                        let y_len = y.len();
+                        // If `y` is shorter, it is a shorthand notation, e.g., `101-7`.
+                        let y = if x_len <= y_len {
+                            y.to_string()
+                        } else {
+                            // Expand `y` to include the missing starting digits from `x`.
+                            let mut s = x[..(x_len - y_len)].to_string();
+                            s.push_str(y);
+                            s
+                        };
+
+                        // Write what stays the same early
+                        write!(buf, "{pref}{x}{separator}")?;
+
+                        // https://docs.citationstyles.org/en/stable/specification.html#appendix-v-page-range-formats
+                        match self {
+                            PageRangeFormat::Chicago15 | PageRangeFormat::Chicago16
+                                if x_len < 3 || x.ends_with("00") =>
+                            {
+                                // For `x` < 100 or multiples of 100, write all digits.
+                                write!(buf, "{y}")
+                            }
+                            PageRangeFormat::Chicago15 | PageRangeFormat::Chicago16
+                                if x[x_len - 2..].starts_with("0") =>
+                            {
+                                // For 1 < `x` % 100 < 10, use changed part only.
+                                minimal(buf, 1, x, &y)
+                            }
+                            PageRangeFormat::Chicago15
+                                if x_len == 4 && changed_digits(x, &y) >= 3 =>
+                            {
+                                // If `x` has 4 digits and 3 change, write all digits.
+                                write!(buf, "{y}")
+                            }
+                            PageRangeFormat::Chicago15 | PageRangeFormat::Chicago16 => {
+                                // Otherwise (for Chicago), write at least 2 digits.
+                                minimal(buf, 2, x, &y)
+                            }
+                            PageRangeFormat::Expanded => write!(buf, "{pref}{y}"),
+                            PageRangeFormat::Minimal => minimal(buf, 1, x, &y),
+                            PageRangeFormat::MinimalTwo => minimal(buf, 2, x, &y),
+                        }
+                    } else {
+                        // Prefix is different, write with `-` to follow citeproc test suite.
+                        write!(buf, "{start}-{end}")
+                    }
                 }
-            }
-            PageRangeFormat::Chicago15
-            | PageRangeFormat::Chicago16
-            | PageRangeFormat::MinimalTwo => {
-                write!(buf, "{}", changed_part(range.start, end, 1))
-            }
+            })
+            .collect()
+    }
+}
+
+/// Calculates how many digits are different between `x` and `y`, starting from the back.
+///
+/// Returns as soon as two digits differ. (In that part we differ from the Haskell version. I think this makes more sense.)
+fn changed_digits(x: &str, y: &str) -> usize {
+    let x = if x.len() < y.len() {
+        let mut s = String::from_iter(repeat(' ').take(y.len() - x.len()));
+        s.push_str(x);
+        s
+    } else {
+        x.to_string()
+    };
+    debug_assert!(x.len() == y.len());
+    let xs = x.chars().rev();
+    let ys = y.chars().rev();
+
+    for (i, (c, d)) in xs.zip(ys).enumerate() {
+        if c == d {
+            return i;
         }
     }
+
+    x.len()
 }
 
-// Taken from https://github.com/citation-style-language/citeproc-rs/blob/master/crates/proc/src/page_range.rs
-fn closest_smaller_power_of_10(num: i32) -> i32 {
-    let answer = 10_f64.powf((num as f64).log10().floor()) as i32;
-
-    // these properties need to hold. I think they do, but the float conversions
-    // might mess things up...
-    debug_assert!(answer <= num);
-    debug_assert!(answer > num / 10);
-    answer
-}
-
-// Taken from https://github.com/citation-style-language/citeproc-rs/blob/master/crates/proc/src/page_range.rs
-fn expand(a: i32, b: i32) -> i32 {
-    let mask = closest_smaller_power_of_10(b) * 10;
-    (a - (a % mask)) + (b % mask)
-}
-
-fn changed_part(a: i32, b: i32, min: u32) -> i32 {
-    let mut base = (a.max(b) as f32).log10().floor() as u32;
-
-    // Check whether the digit at the given base is the same
-    while {
-        let a_digit = a / 10_i32.pow(base);
-        let b_digit = b / 10_i32.pow(base);
-        a_digit == b_digit && base > min
-    } {
-        base -= 1;
+/// Writes the minimal digits that have changed from `x` to `y`---but at minimum `thresh` digits---to `buf`.
+fn minimal(
+    buf: &mut impl fmt::Write,
+    thresh: usize,
+    x: &str,
+    y: &str,
+) -> Result<(), fmt::Error> {
+    let mut xs = String::new();
+    let mut ys = String::new();
+    for (c, d) in x.chars().zip(y.chars()).skip_while(|(c, d)| c == d) {
+        xs.push(c);
+        ys.push(d);
     }
 
-    b % 10_i32.pow(base + 1)
+    if ys.len() < thresh && y.len() >= thresh {
+        write!(buf, "{}", &y[(y.len() - thresh)..])
+    } else {
+        write!(buf, "{ys}")
+    }
+}
+
+/// Split `s` into the maximal suffix that is only digits and a prefix.
+fn split_max_digit_suffix(s: &str) -> (&str, &str) {
+    let suffix_len = s.chars().rev().take_while(|c| c.is_digit(10)).count();
+    let idx = s.len() - suffix_len;
+    (&s[..idx], &s[idx..])
 }
 
 /// How to treat the non-dropping name particle when printing names.
@@ -3653,18 +3722,10 @@ mod test {
     }
 
     #[test]
-    fn test_expand() {
-        assert_eq!(expand(103, 4), 104);
-        assert_eq!(expand(133, 4), 134);
-        assert_eq!(expand(133, 54), 154);
-        assert_eq!(expand(100, 4), 104);
-    }
-
-    #[test]
     fn page_range() {
-        fn run(format: PageRangeFormat, start: i32, end: i32) -> String {
+        fn run(format: PageRangeFormat, range: &str) -> String {
             let mut buf = String::new();
-            format.format(start..end, &mut buf, None).unwrap();
+            format.format(range, &mut buf, None).unwrap();
             buf
         }
 
@@ -3676,49 +3737,78 @@ mod test {
 
         // https://docs.citationstyles.org/en/stable/specification.html#appendix-v-page-range-formats
 
-        assert_eq!("3–10", run(c15, 3, 10));
-        assert_eq!("71–72", run(c15, 71, 72));
-        assert_eq!("100–104", run(c15, 100, 4));
-        assert_eq!("600–613", run(c15, 600, 613));
-        assert_eq!("1100–1123", run(c15, 1100, 1123));
-        assert_eq!("107–8", run(c15, 107, 108));
-        assert_eq!("505–17", run(c15, 505, 517));
-        assert_eq!("1002–6", run(c15, 1002, 1006));
-        assert_eq!("321–25", run(c15, 321, 325));
-        assert_eq!("415–532", run(c15, 415, 532));
-        assert_eq!("11564–68", run(c15, 11564, 11568));
-        assert_eq!("13792–803", run(c15, 13792, 13803));
-        assert_eq!("1496–1504", run(c15, 1496, 1504));
-        assert_eq!("2787–2816", run(c15, 2787, 2816));
+        assert_eq!("3–10", run(c15, "3-10"));
+        assert_eq!("71–72", run(c15, "71-72"));
+        assert_eq!("100–104", run(c15, "100-4"));
+        assert_eq!("600–613", run(c15, "600-613"));
+        assert_eq!("1100–1123", run(c15, "1100-1123"));
+        assert_eq!("107–8", run(c15, "107-108"));
+        assert_eq!("505–17", run(c15, "505-517"));
+        assert_eq!("1002–6", run(c15, "1002-1006"));
+        assert_eq!("321–25", run(c15, "321-325"));
+        assert_eq!("415–532", run(c15, "415-532"));
+        assert_eq!("11564–68", run(c15, "11564-11568"));
+        assert_eq!("13792–803", run(c15, "13792-13803"));
+        assert_eq!("1496–1504", run(c15, "1496-1504"));
+        assert_eq!("2787–2816", run(c15, "2787-2816"));
 
-        assert_eq!("3–10", run(c16, 3, 10));
-        assert_eq!("71–72", run(c16, 71, 72));
-        assert_eq!("92–113", run(c16, 92, 113));
-        assert_eq!("100–104", run(c16, 100, 4));
-        assert_eq!("600–613", run(c16, 600, 613));
-        assert_eq!("1100–1123", run(c16, 1100, 1123));
-        assert_eq!("107–8", run(c16, 107, 108));
-        assert_eq!("505–17", run(c16, 505, 517));
-        assert_eq!("1002–6", run(c16, 1002, 1006));
-        assert_eq!("321–25", run(c16, 321, 325));
-        assert_eq!("415–532", run(c16, 415, 532));
-        assert_eq!("1087–89", run(c16, 1087, 1089));
-        assert_eq!("1496–500", run(c16, 1496, 1500));
-        assert_eq!("11564–68", run(c16, 11564, 11568));
-        assert_eq!("13792–803", run(c16, 13792, 13803));
-        assert_eq!("12991–3001", run(c16, 12991, 13001));
+        assert_eq!("3–10", run(c16, "3-10"));
+        assert_eq!("71–72", run(c16, "71-72"));
+        assert_eq!("92–113", run(c16, "92-113"));
+        assert_eq!("100–104", run(c16, "100-4"));
+        assert_eq!("600–613", run(c16, "600-613"));
+        assert_eq!("1100–1123", run(c16, "1100-1123"));
+        assert_eq!("107–8", run(c16, "107-108"));
+        assert_eq!("505–17", run(c16, "505-517"));
+        assert_eq!("1002–6", run(c16, "1002-1006"));
+        assert_eq!("321–25", run(c16, "321-325"));
+        assert_eq!("415–532", run(c16, "415-532"));
+        assert_eq!("1087–89", run(c16, "1087-1089"));
+        assert_eq!("1496–500", run(c16, "1496-1500"));
+        assert_eq!("11564–68", run(c16, "11564-11568"));
+        assert_eq!("13792–803", run(c16, "13792-13803"));
+        assert_eq!("12991–3001", run(c16, "12991-13001"));
 
-        assert_eq!("42–45", run(exp, 42, 45));
-        assert_eq!("321–328", run(exp, 321, 328));
-        assert_eq!("2787–2816", run(exp, 2787, 2816));
+        assert_eq!("42–45", run(exp, "42-45"));
+        assert_eq!("321–328", run(exp, "321-328"));
+        assert_eq!("2787–2816", run(exp, "2787-2816"));
 
-        assert_eq!("42–5", run(min, 42, 45));
-        assert_eq!("321–8", run(min, 321, 328));
-        assert_eq!("2787–816", run(min, 2787, 2816));
+        assert_eq!("42–5", run(min, "42-45"));
+        assert_eq!("321–8", run(min, "321-328"));
+        assert_eq!("2787–816", run(min, "2787-2816"));
 
-        assert_eq!("7–8", run(mi2, 7, 8));
-        assert_eq!("42–45", run(mi2, 42, 45));
-        assert_eq!("321–28", run(mi2, 321, 328));
-        assert_eq!("2787–816", run(mi2, 2787, 2816));
+        assert_eq!("7–8", run(mi2, "7-8"));
+        assert_eq!("42–45", run(mi2, "42-45"));
+        assert_eq!("321–28", run(mi2, "321-328"));
+        assert_eq!("2787–816", run(mi2, "2787-2816"));
+    }
+
+    #[test]
+    fn page_range_prefix() {
+        fn run(format: PageRangeFormat, range: &str) -> String {
+            let mut buf = String::new();
+            format.format(range, &mut buf, None).unwrap();
+            buf
+        }
+
+        let c15 = PageRangeFormat::Chicago15;
+        let exp = PageRangeFormat::Expanded;
+        let min = PageRangeFormat::Minimal;
+
+        assert_eq!("8n11564–68", run(c15, "8n11564-8n1568"));
+        assert_eq!("n11564–68", run(c15, "n11564-n1568"));
+        assert_eq!("n11564-1568", run(c15, "n11564-1568"));
+
+        assert_eq!("N110-5", run(exp, "N110 - 5"));
+        assert_eq!("N110–N115", run(exp, "N110 - N5"));
+        assert_eq!("110-N6", run(exp, "110 - N6"));
+        assert_eq!("N110-P5", run(exp, "N110 - P5"));
+        assert_eq!("123N110-N5", run(exp, "123N110 - N5"));
+        assert_eq!("123N110-N5, 456K200-99", run(exp, "123N110 - N5, 456K200 - 99"));
+        assert_eq!("123N110-N5, 000c23-22", run(exp, "123N110 - N5, 000c23 - 22"));
+        assert_eq!("123N110-N5, 456K200-99", run(exp, "123N110 - N5, 456K200 - 99"));
+
+        assert_eq!("n11564–8", run(min, "n11564 - n1568"));
+        assert_eq!("n11564-1568", run(min, "n11564 - 1568"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -649,7 +649,11 @@ impl PageRangeFormat {
         let separator = separator.unwrap_or("–");
 
         write!(buf, "{}{}", range.start, separator)?;
-        let end = range.end;
+        let end = if range.end >= range.start {
+            range.end
+        } else {
+            expand(range.start, range.end)
+        };
 
         match self {
             _ if range.start < 0 || range.end < 0 => write!(buf, "{}", end),
@@ -661,38 +665,60 @@ impl PageRangeFormat {
                 write!(buf, "{}", end)
             }
             PageRangeFormat::Minimal => {
-                write!(buf, "{}", changed_part(range.start, end))
+                write!(buf, "{}", changed_part(range.start, end, 0))
             }
             PageRangeFormat::MinimalTwo if end < 10 => {
-                write!(buf, "{}", changed_part(range.start, end))
+                write!(buf, "{}", changed_part(range.start, end, 1))
             }
             PageRangeFormat::Chicago15
                 if range.start > 100 && (1..10).contains(&(range.start % 100)) =>
             {
-                write!(buf, "{}", changed_part(range.start, end))
+                write!(buf, "{}", changed_part(range.start, end, 0))
             }
             PageRangeFormat::Chicago15
-                if range.start > 1000 && end - range.start >= 100 =>
+                if closest_smaller_power_of_10(range.start) == 1000 =>
             {
-                write!(buf, "{}", end)
+                let changed = changed_part(range.start, end, 1);
+                if closest_smaller_power_of_10(changed) == 100 {
+                    write!(buf, "{end}")
+                } else {
+                    write!(buf, "{changed}")
+                }
             }
             PageRangeFormat::Chicago15
             | PageRangeFormat::Chicago16
             | PageRangeFormat::MinimalTwo => {
-                write!(buf, "{:02}", changed_part(range.start, end))
+                write!(buf, "{}", changed_part(range.start, end, 1))
             }
         }
     }
 }
 
-fn changed_part(a: i32, b: i32) -> i32 {
-    let mut base = (a.max(b) as f32).log10().floor() as u32 - 1;
+// Taken from https://github.com/citation-style-language/citeproc-rs/blob/master/crates/proc/src/page_range.rs
+fn closest_smaller_power_of_10(num: i32) -> i32 {
+    let answer = 10_f64.powf((num as f64).log10().floor()) as i32;
+
+    // these properties need to hold. I think they do, but the float conversions
+    // might mess things up...
+    debug_assert!(answer <= num);
+    debug_assert!(answer > num / 10);
+    answer
+}
+
+// Taken from https://github.com/citation-style-language/citeproc-rs/blob/master/crates/proc/src/page_range.rs
+fn expand(a: i32, b: i32) -> i32 {
+    let mask = closest_smaller_power_of_10(b) * 10;
+    (a - (a % mask)) + (b % mask)
+}
+
+fn changed_part(a: i32, b: i32, min: u32) -> i32 {
+    let mut base = (a.max(b) as f32).log10().floor() as u32;
 
     // Check whether the digit at the given base is the same
     while {
         let a_digit = a / 10_i32.pow(base);
         let b_digit = b / 10_i32.pow(base);
-        a_digit == b_digit && base != 0
+        a_digit == b_digit && base > min
     } {
         base -= 1;
     }
@@ -3624,5 +3650,20 @@ mod test {
             let locale2 = from_cbor(&cbor);
             assert_eq!(locale, locale2);
         }
+    }
+
+    #[test]
+    fn test_expand() {
+        assert_eq!(expand(103, 4), 104);
+        assert_eq!(expand(133, 4), 134);
+        assert_eq!(expand(133, 54), 154);
+        assert_eq!(expand(100, 4), 104);
+    }
+
+    #[test]
+    fn page_range() {
+        let mut buf = String::new();
+        PageRangeFormat::Chicago15.format(100..4, &mut buf, None).unwrap();
+        assert_eq!("100–104", buf);
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use serde::Deserialize;
 
 pub fn deserialize_bool<'de, D: serde::Deserializer<'de>>(
@@ -69,4 +71,100 @@ pub fn deserialize_u32_option<'de, D: serde::Deserializer<'de>>(
         StringOrUnsigned::String(s) => s.trim().parse().map_err(serde::de::Error::custom),
     })
     .transpose()
+}
+
+/// Split `s` into maximal chunks such that two successive chars satisfy `pred`.
+///
+/// Returns an iterator over these chunks.
+pub(crate) fn group_by<'a, F>(s: &'a str, pred: F) -> GroupBy<'a, F>
+where
+    F: FnMut(char, char) -> bool,
+{
+    GroupBy::new(s, pred)
+}
+
+/// An iterator over string slice in (non-overlapping) chunks separated by a predicate.
+///
+/// Adapted from the nightly std.
+pub(crate) struct GroupBy<'a, P> {
+    string: &'a str,
+    predicate: P,
+}
+
+impl<'a, P> GroupBy<'a, P> {
+    pub(crate) fn new(string: &'a str, predicate: P) -> Self {
+        GroupBy { string, predicate }
+    }
+}
+
+impl<'a, P> Iterator for GroupBy<'a, P>
+where
+    P: FnMut(char, char) -> bool,
+{
+    type Item = &'a str;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.string.is_empty() {
+            None
+        } else {
+            let mut len = 1;
+            let mut iter = windows(self.string, 2);
+            while let Some(w) = iter.next() {
+                let chars: Vec<_> = w.chars().collect();
+                let (c, d) = (chars[0], chars[1]);
+                if (self.predicate)(c, d) {
+                    len += 1
+                } else {
+                    break;
+                }
+            }
+            let (head, tail) = self.string.split_at(len);
+            self.string = tail;
+            Some(head)
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.string.chars().size_hint()
+    }
+}
+
+/// Return an iterator of sliding windows of size `size` over `string`.
+///
+/// # Panic
+///
+/// Panics if `size` is zero.
+pub(crate) fn windows(string: &str, size: usize) -> Windows<'_> {
+    assert!(size > 0);
+    Windows::new(string, NonZeroUsize::new(size).unwrap())
+}
+
+/// An iterator of sliding windows of size `size` over `string`.
+///
+/// Each call of `next` advanced the window by one.
+pub(crate) struct Windows<'a> {
+    string: &'a str,
+    size: NonZeroUsize,
+}
+
+impl<'a> Windows<'a> {
+    pub(crate) fn new(string: &'a str, size: NonZeroUsize) -> Self {
+        Self { string, size }
+    }
+}
+
+impl<'a> Iterator for Windows<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.size.get() > self.string.len() {
+            None
+        } else {
+            let ret = Some(&self.string[..self.size.get()]);
+            self.string = &self.string[1..];
+            ret
+        }
+    }
 }


### PR DESCRIPTION
(This is a big change; I apologize.)

This PR changes formatting of page ranges entirely. In summary

1. `PageRangeFormat::format` no longer accepts `start` and `end` parameters of type `i32`; instead it expects a `&str`
2. The function now handles a list of ranges, separated by `&` or `,`; each range is rendered separately and then joined with the respective connective
3. Each range may now have a prefix. E.g., `8n11564-8n1568` is formatted to `8n11564–68` by Chicago15. (The prefix **must** be identical for start and end of the range!)

I followed the [Haskell implementation of pandoc](https://hackage.haskell.org/package/citeproc-0.8.1/docs/src/Citeproc.Eval.html#pageRange) pretty closely, while trying to be as efficient as possible and writing it like one would in Rust. I would not be surprised if it can be optimized further.

Two points should be cleared up before merging:
- [ ] Should we follow the citeproc test suite exactly? Prefixes, while important for many texts, are not mentioned in the CSL spec. In particular, the test suite demands that `123N110 - N5` is turned to `123N110-N5` by `Expanded` (note that no en-dash is used!). I would prefer the given separator instead of the normal dash. This is a matter of taste.
- [ ] Should the _parsing_ of the ranges be done by Citationberg while rendering or should Citationberg have a more complex data structure for ranges that is created by hayagriva and then only rendered by Citationberg? This is a question of where we want this to be handled: Should accessing a hayagriva `Library` expose the structure of the ranges _without rendering using CSL_ or should it be seen as part of CSL?

This would be the second API change to citationberg. If merged, we should have a new version.