### PR TITLE
Fix fallback on subsequent name options not set

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2453,9 +2453,12 @@ impl NameOptions<'_> {
             return false;
         }
 
-        // If this is a subsequent citation of the same item, use other CSL options
+        // If this is a subsequent citation of the same item, use other CSL options, if they exist
         let (et_al_min, et_al_use_first) = if is_subsequent {
-            (self.et_al_subsequent_min, self.et_al_subsequent_use_first)
+            (
+                self.et_al_subsequent_min.or(self.et_al_min),
+                self.et_al_subsequent_use_first.or(self.et_al_use_first),
+            )
         } else {
             (self.et_al_min, self.et_al_use_first)
         };


### PR DESCRIPTION
From the [CSL Spec](https://docs.citationstyles.org/en/stable/specification.html?#name) it is suggested that
```
et-al-subsequent-min / et-al-subsequent-use-first
    If used, the values of these attributes replace those of respectively
    et-al-min and et-al-use-first for subsequent cites
    (cites referencing earlier cited items).
```
Therefore we need to fallback if `et_al_subsequent` are `None`

Fixes #10 
Also fixes typst/hayagriva#141
