### PR TITLE
Support `editor-translator` term

### DIFF
--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -431,7 +431,7 @@ pub enum NameVariable {
     /// Combined editor and translator of a work; The citation processory must
     /// be automatically generate if editor and translator variables are
     /// identical; May also be provided directly in item data.
-    #[serde(rename = "editortranslator")]
+    #[serde(alias = "editortranslator")]
     EditorTranslator,
     /// Executive producer (e.g. of a television series).
     ExecutiveProducer,
@@ -496,7 +496,7 @@ impl fmt::Display for NameVariable {
             Self::Director => write!(f, "director"),
             Self::Editor => write!(f, "editor"),
             Self::EditorialDirector => write!(f, "editorial-director"),
-            Self::EditorTranslator => write!(f, "editortranslator"),
+            Self::EditorTranslator => write!(f, "editor-translator"),
             Self::ExecutiveProducer => write!(f, "executive-producer"),
             Self::Guest => write!(f, "guest"),
             Self::Host => write!(f, "host"),


### PR DESCRIPTION
Fixes https://github.com/typst/hayagriva/issues/187 (and therefore should fix hayagriva's CI)

Right now, I'm just considering `editor-translator` and `editortranslator` to represent the same thing: a term that is used when the editor and the translator are the same in a CSL `<names>`.

At the time of writing, the only official styles in https://github.com/citation-style-language/styles that appear to be using this term are APA styles, which define `editortranslator` and `editor-translator` to be the same. Other styles are still using only `editortranslator`.

It is theoretically possible for the two terms to have separate definitions in a locale, so maybe this PR's approach of expecting both to be the same could be too naive. However, it's still an improvement over the status quo - currently, APA styles fail to parse with a rather obtuse error (`Custom("data did not match any variant of untagged enum Term")`). Regardless, we could consider creating a separate term variant, e.g. `EditorTranslatorOld` for `"editortranslator"` and `EditorTranslator` for `"editor-translator"`.