### PR TITLE
Use NumberOrPageVariable for Number element

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,8 @@ use std::num::{NonZeroI16, NonZeroUsize};
 use quick_xml::de::{Deserializer, SliceReader};
 use serde::{Deserialize, Serialize};
 use taxonomy::{
-    DateVariable, Kind, Locator, NameVariable, NumberOrPageVariable, NumberVariable,
-    OtherTerm, Term, Variable,
+    DateVariable, Kind, Locator, NameVariable, NumberOrPageVariable, OtherTerm, Term,
+    Variable,
 };
 
 use self::util::*;
@@ -1481,7 +1481,7 @@ impl LayoutRenderingElement {
                 }
             }
             Self::Number(n) => {
-                if Variable::Number(n.variable) == variable {
+                if Variable::from(n.variable) == variable {
                     Some(self.clone())
                 } else {
                     None
@@ -1899,7 +1899,7 @@ pub enum LongShortForm {
 pub struct Number {
     /// The variable whose value is used.
     #[serde(rename = "@variable")]
-    pub variable: NumberVariable,
+    pub variable: NumberOrPageVariable,
     /// How the number is formatted.
     #[serde(rename = "@form", default)]
     pub form: NumberForm,

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -257,15 +257,24 @@ impl fmt::Display for StandardVariable {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
 /// Number variables as the CSL spec knows them, though we separate between
 /// number variables and page ranges.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum NumberOrPageVariable {
     /// The page variable.
     Page(PageVariable),
     /// Variables formattable as numbers.
     Number(NumberVariable),
+}
+
+impl From<NumberOrPageVariable> for Variable {
+    fn from(value: NumberOrPageVariable) -> Self {
+        match value {
+            NumberOrPageVariable::Page(p) => p.into(),
+            NumberOrPageVariable::Number(n) => n.into(),
+        }
+    }
 }
 
 impl From<NumberOrPageVariable> for Term {


### PR DESCRIPTION
Fixes a regression from #14. We were allowing `"page"` for `<label variable="...">` but not for `<number variable="...">`.