### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ default = []
 json = ["unscanny"] # adds support for CSL-json parsing
 
 [dependencies]
-quick-xml = { version = "0.36.2", features = ["serialize", "overlapped-lists"] }
+quick-xml = { version = "0.38.1", features = ["serialize", "overlapped-lists"] }
 serde = { version = "1.0", features = ["derive"] }
 unscanny = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
-ciborium = "0.2.1"
-serde_json = "1.0.107"
+ciborium = "0.2.2"
+serde_json = "1.0"
 serde_path_to_error = "0.1"

--- a/src/json.rs
+++ b/src/json.rs
@@ -15,12 +15,12 @@ pub struct Item(pub BTreeMap<String, Value>);
 
 impl Item {
     /// The item's ID.
-    pub fn id(&self) -> Option<Cow<str>> {
+    pub fn id(&self) -> Option<Cow<'_, str>> {
         self.0.get("id")?.to_str()
     }
 
     /// The item type.
-    pub fn type_(&self) -> Option<Cow<str>> {
+    pub fn type_(&self) -> Option<Cow<'_, str>> {
         self.0.get("type")?.to_str()
     }
 
@@ -51,7 +51,7 @@ pub enum Value {
 
 impl Value {
     /// Convert to a string if this is a string or number.
-    pub fn to_str(&self) -> Option<Cow<str>> {
+    pub fn to_str(&self) -> Option<Cow<'_, str>> {
         match self {
             Value::String(s) => Some(s.as_str().into()),
             Value::Number(n) => Some(n.to_string().into()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,11 +53,17 @@ use taxonomy::{
 
 use self::util::*;
 
-/// Result type for functions that serialize and deserialize XML.
-pub type XmlResult<T> = Result<T, XmlError>;
+/// Result type for functions that deserialize XML.
+pub type XmlDeResult<T> = Result<T, XmlDeError>;
 
-/// Error type for functions that serialize and deserialize XML.
-pub type XmlError = quick_xml::de::DeError;
+/// Error type for functions that deserialize XML.
+pub type XmlDeError = quick_xml::de::DeError;
+
+/// Result type for functions that serialize XML.
+pub type XmlSeResult<T> = Result<T, XmlSeError>;
+
+/// Error type for functions that serialize XML.
+pub type XmlSeError = quick_xml::se::SeError;
 
 const EVENT_BUFFER_SIZE: Option<NonZeroUsize> = NonZeroUsize::new(8192);
 
@@ -220,7 +226,7 @@ pub struct IndependentStyle {
 
 impl IndependentStyle {
     /// Create a style from an XML string.
-    pub fn from_xml(xml: &str) -> XmlResult<Self> {
+    pub fn from_xml(xml: &str) -> XmlDeResult<Self> {
         let de = &mut deserializer(xml);
         IndependentStyle::deserialize(de)
     }
@@ -273,7 +279,7 @@ pub struct DependentStyle {
 
 impl DependentStyle {
     /// Create a style from an XML string.
-    pub fn from_xml(xml: &str) -> XmlResult<Self> {
+    pub fn from_xml(xml: &str) -> XmlDeResult<Self> {
         let de = &mut deserializer(xml);
         DependentStyle::deserialize(de)
     }
@@ -313,13 +319,13 @@ pub enum Style {
 
 impl Style {
     /// Create a style from an XML string.
-    pub fn from_xml(xml: &str) -> XmlResult<Self> {
+    pub fn from_xml(xml: &str) -> XmlDeResult<Self> {
         let de = &mut deserializer(xml);
         Style::deserialize(de)
     }
 
     /// Write the style to an XML string.
-    pub fn to_xml(&self) -> XmlResult<String> {
+    pub fn to_xml(&self) -> XmlSeResult<String> {
         let mut buf = String::new();
         let ser = quick_xml::se::Serializer::with_root(&mut buf, Some("style"))?;
         self.serialize(ser)?;
@@ -2933,7 +2939,7 @@ pub struct LocaleFile {
     #[serde(rename = "@version")]
     pub version: String,
     /// Which languages or dialects this data applies to.
-    #[serde(rename = "@lang")]
+    #[serde(rename = "@xml:lang")]
     pub lang: LocaleCode,
     /// Metadata of the locale.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2951,13 +2957,13 @@ pub struct LocaleFile {
 
 impl LocaleFile {
     /// Create a locale from an XML string.
-    pub fn from_xml(xml: &str) -> XmlResult<Self> {
+    pub fn from_xml(xml: &str) -> XmlDeResult<Self> {
         let locale: Self = quick_xml::de::from_str(xml)?;
         Ok(locale)
     }
 
     /// Write the locale to an XML string.
-    pub fn to_xml(&self) -> XmlResult<String> {
+    pub fn to_xml(&self) -> XmlSeResult<String> {
         let mut buf = String::new();
         let ser = quick_xml::se::Serializer::with_root(&mut buf, Some("style"))?;
         self.serialize(ser)?;


### PR DESCRIPTION
Note: 
- I had to add new error and result types since quick_xml now uses separate error types for serialization and deserialization.
- I had to change the `lang` attribute to match `xml:lang`