### PR TITLE
Bump EVENT_BUFFER_SIZE to u32::MAX

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub type XmlSeResult<T> = Result<T, XmlSeError>;
 /// Error type for functions that serialize XML.
 pub type XmlSeError = quick_xml::se::SeError;
 
-const EVENT_BUFFER_SIZE: Option<NonZeroUsize> = NonZeroUsize::new(60000);
+const EVENT_BUFFER_SIZE: Option<NonZeroUsize> = NonZeroUsize::new(u32::MAX as usize);
 
 /// Allow every struct with formatting properties to convert to a `Formatting`.
 pub trait ToFormatting {


### PR DESCRIPTION
No reason to keep it low.