### PR TITLE
Specify rust components on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets
       - run: cargo fmt --check --all


### PR DESCRIPTION
Fixes some CI failures when trying to use clippy or rustfmt