### PR TITLE
Fix json feature and future proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           git clone --depth 1 https://github.com/citation-style-language/locales
       - uses: Swatinem/rust-cache@v2
       - run: cargo build
-      - run: cargo test
+      - run: cargo test --all-features
 
   checks:
     name: Check clippy, formatting, and documentation
@@ -29,7 +29,7 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all-targets
+      - run: cargo clippy --all-targets --all-features
       - run: cargo fmt --check --all
       - run: cargo doc --no-deps
 
@@ -40,4 +40,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check
+      - run: cargo check --all-features --all-targets

--- a/src/json.rs
+++ b/src/json.rs
@@ -137,7 +137,7 @@ impl TryFrom<DateValue> for FixedDateRange {
         };
         fixed.start.season = season
             .and_then(|s| s.parse::<u8>().ok())
-            .and_then(|u| u.try_into().ok());
+            .and_then(|u| Season::try_from_csl_number(u).ok());
         Ok(fixed)
     }
 }


### PR DESCRIPTION
The recent PR #33 was merged prematurely: When the json feature is enabled, there is a type error. This is not caught by the CI because `all-features` is missing.

This PR fixes the code and adds the additional flags to check, test, and clippy on the CI.