### PR TITLE
Correct typos and fix a clippy error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use std::fs;
 use citationberg::Style;
 
 let string = fs::read_to_string("tests/independent/ieee.csl")?;
-let style = citationberg::Style::from_xml(&string)?;
+let style = Style::from_xml(&string)?;
 
 let Style::Independent(independent) = style else {
     panic!("IEEE is an independent style");
@@ -794,7 +794,7 @@ pub struct StyleInfo {
     /// Contributors to the style
     #[serde(rename = "contributor")]
     #[serde(default)]
-    pub contibutors: Vec<StyleAttribution>,
+    pub contributors: Vec<StyleAttribution>,
     /// Which format the citations are in.
     #[serde(default)]
     pub category: Vec<StyleCategory>,
@@ -847,7 +847,8 @@ impl StyleInfo {
 
         match level {
             PurgeLevel::Basic => {
-                for person in self.authors.iter_mut().chain(self.contibutors.iter_mut()) {
+                for person in self.authors.iter_mut().chain(self.contributors.iter_mut())
+                {
                     person.email = None;
                     person.uri = None;
                 }
@@ -857,7 +858,7 @@ impl StyleInfo {
             }
             PurgeLevel::Full => {
                 self.authors.clear();
-                self.contibutors.clear();
+                self.contributors.clear();
                 self.link.retain(|i| i.rel == InfoLinkRel::IndependentParent);
                 self.rights = None;
             }
@@ -2657,7 +2658,7 @@ pub struct VariablelessLabel {
     /// What variant of label is chosen.
     #[serde(rename = "@form", default)]
     pub form: TermForm,
-    /// How to pluiralize the label.
+    /// How to pluralize the label.
     #[serde(rename = "@plural", default)]
     pub plural: LabelPluralize,
     /// Override formatting style.
@@ -3461,7 +3462,7 @@ pub enum Display {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum TextCase {
-    /// lowecase.
+    /// lowercase.
     Lowercase,
     /// UPPERCASE.
     Uppercase,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3159,10 +3159,10 @@ impl TryFrom<Locale> for LocaleFile {
     type Error = ();
 
     fn try_from(value: Locale) -> Result<Self, Self::Error> {
-        if value.lang.is_some() {
+        if let Some(lang) = value.lang {
             Ok(Self {
                 version: "1.0".to_string(),
-                lang: value.lang.unwrap(),
+                lang,
                 info: value.info,
                 terms: value.terms,
                 date: value.date,

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -483,8 +483,8 @@ pub enum NameVariable {
     Editor,
     /// Managing editor (“Directeur de la Publication” in French).
     EditorialDirector,
-    /// Combined editor and translator of a work; The citation processory must
-    /// be automatically generate if editor and translator variables are
+    /// Combined editor and translator of a work; The citation processor must
+    /// automatically generate it if editor and translator variables are
     /// identical; May also be provided directly in item data.
     #[serde(alias = "editortranslator")]
     EditorTranslator,
@@ -508,7 +508,7 @@ pub enum NameVariable {
     /// developer or programmer for a piece of software; the original author of
     /// an adapted work such as a book adapted into a screenplay).
     OriginalAuthor,
-    /// Performer of an item (e.g. an actor appearing in a film; a muscian
+    /// Performer of an item (e.g. an actor appearing in a film; a musician
     /// performing a piece of music).
     Performer,
     /// Producer (e.g. of a television or radio broadcast).


### PR DESCRIPTION
Resolves #21

Relates to https://github.com/citation-style-language/documentation/pull/156 (already merged), which syncs changes in `taxonomy.rs` here.

---

Also fixes clippy unnecessary_unwrap error.

```log
error: called `unwrap` on `value.lang` after checking its variant with `is_some`
    --> src/lib.rs:3165:23
     |
3162 |         if value.lang.is_some() {
     |         ----------------------- help: try: `if let Some(<item>) = value.lang`
...
3165 |                 lang: value.lang.unwrap(),
     |                       ^^^^^^^^^^^^^^^^^^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#unnecessary_unwrap
     = note: `-D clippy::unnecessary-unwrap` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::unnecessary_unwrap)]`

error: could not compile `citationberg` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `citationberg` (lib test) due to 1 previous error
```
